### PR TITLE
Refine ServoControl plugin integration with custom overrides

### DIFF
--- a/custom/CMakeLists.txt
+++ b/custom/CMakeLists.txt
@@ -73,6 +73,10 @@ set(CUSTOM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/HerelinkCorePlugin.json
     ${CMAKE_CURRENT_SOURCE_DIR}/src/HerelinkOptions.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/HerelinkOptions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ServoControlController.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ServoControlController.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ServoControlSettings.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ServoControlSettings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/herelink/VideoStreamControl.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/herelink/VideoStreamControl.h
     CACHE INTERNAL "" FORCE

--- a/custom/custom.qrc
+++ b/custom/custom.qrc
@@ -5,6 +5,12 @@
     </qresource>
     <qresource prefix="Custom/Widgets">
     </qresource>
+    <qresource prefix="/json">
+        <file alias="ServoControl.SettingsGroup.json">src/ServoControl.SettingsGroup.json</file>
+    </qresource>
     <qresource prefix="/qml">
+        <file alias="Custom/ServoControl/ServoControlSettingsPage.qml">res/ServoControl/ServoControlSettingsPage.qml</file>
+        <file alias="QGroundControl/AppSettings/SettingsPagesModel.qml">res/Custom/AppSettings/SettingsPagesModel.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">res/ServoControl/FlyViewCustomLayer.qml</file>
     </qresource>
 </RCC>

--- a/custom/res/Custom/AppSettings/SettingsPagesModel.qml
+++ b/custom/res/Custom/AppSettings/SettingsPagesModel.qml
@@ -1,0 +1,132 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQml.Models
+
+import QGroundControl
+import QGroundControl.ScreenTools
+
+ListModel {
+    ListElement {
+        name: qsTr("General")
+        url: "qrc:/qml/QGroundControl/AppSettings/GeneralSettings.qml"
+        iconUrl: "qrc:/res/QGCLogoWhite.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Fly View")
+        url: "qrc:/qml/QGroundControl/AppSettings/FlyViewSettings.qml"
+        iconUrl: "qrc:/qmlimages/PaperPlane.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Plan View")
+        url: "qrc:/qml/QGroundControl/AppSettings/PlanViewSettings.qml"
+        iconUrl: "qrc:/qmlimages/Plan.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Video")
+        url: "qrc:/qml/QGroundControl/AppSettings/VideoSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/camera.svg"
+        pageVisible: function() { return QGroundControl.settingsManager.videoSettings.visible }
+    }
+
+    ListElement {
+        name: qsTr("Telemetry")
+        url: "qrc:/qml/QGroundControl/AppSettings/TelemetrySettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/drone.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("ADSB Server")
+        url: "qrc:/qml/QGroundControl/AppSettings/ADSBServerSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/airplane.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Comm Links")
+        url: "qrc:/qml/QGroundControl/AppSettings/LinkSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/usb.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Servo Control")
+        url: "qrc:/qml/Custom/ServoControl/ServoControlSettingsPage.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/wrench.svg"
+        pageVisible: function() { return QGroundControl.corePlugin.servoControlController !== null }
+    }
+
+    ListElement {
+        name: qsTr("Maps")
+        url: "qrc:/qml/QGroundControl/AppSettings/MapSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/globe.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("PX4 Log Transfer")
+        url: "qrc:/qml/QGroundControl/AppSettings/PX4LogTransferSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/inbox-download.svg"
+        pageVisible: function() {
+            var activeVehicle = QGroundControl.multiVehicleManager.activeVehicle
+            return QGroundControl.corePlugin.options.showPX4LogTransferOptions &&
+                        QGroundControl.px4ProFirmwareSupported &&
+                        (activeVehicle ? activeVehicle.px4Firmware : true)
+        }
+    }
+
+    ListElement {
+        name: qsTr("Remote ID")
+        url: "qrc:/qml/QGroundControl/AppSettings/RemoteIDSettings.qml"
+        iconUrl: "qrc:/qmlimages/RidIconManNoID.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Console")
+        url: "qrc:/qml/QGroundControl/Controls/AppMessages.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/conversation.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Help")
+        url: "qrc:/qml/QGroundControl/AppSettings/HelpSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/question.svg"
+        pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Mock Link")
+        url: "qrc:/qml/QGroundControl/AppSettings/MockLink.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/drone.svg"
+        pageVisible: function() { return ScreenTools.isDebug }
+    }
+
+    ListElement {
+        name: qsTr("Debug")
+        url: "qrc:/qml/QGroundControl/AppSettings/DebugWindow.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/bug.svg"
+        pageVisible: function() { return ScreenTools.isDebug }
+    }
+
+    ListElement {
+        name: qsTr("Palette Test")
+        url: "qrc:/qml/QGroundControl/AppSettings/QmlTest.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/photo.svg"
+        pageVisible: function() { return ScreenTools.isDebug }
+    }
+}

--- a/custom/res/ServoControl/FlyViewCustomLayer.qml
+++ b/custom/res/ServoControl/FlyViewCustomLayer.qml
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ * (c) 2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FactSystem
+import QGroundControl.FlightMap
+import QGroundControl.Palette
+import QGroundControl.ScreenTools
+import QGroundControl.Vehicle
+
+Item {
+    id: _root
+
+    property var parentToolInsets               // These insets tell you what screen real estate is available for positioning the controls in your overlay
+    property var totalToolInsets:   _toolInsets // These are the insets for your custom overlay additions
+    property var mapControl
+
+    readonly property var controller: QGroundControl.corePlugin.servoControlController
+
+    readonly property real _buttonMargin: ScreenTools.defaultFontPixelWidth
+
+    Column {
+        id: servoButtonColumn
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: _buttonMargin
+        anchors.bottomMargin: ScreenTools.defaultFontPixelHeight
+        spacing: ScreenTools.defaultFontPixelHeight / 2
+        visible: controller && controller.buttons.length > 0
+
+        Repeater {
+            model: controller ? controller.buttons : []
+
+            delegate: QGCButton {
+                text: modelData.name
+                checkable: true
+                checked: controller && controller.activeButtonIndex === index
+                primary: checked
+                onClicked: controller.triggerButton(index)
+                enabled: QGroundControl.multiVehicleManager.activeVehicle !== null
+
+                ToolTip.visible: hovered
+                ToolTip.delay: 0
+                ToolTip.text: qsTr("Servo %1 • %2 µs").arg(modelData.servoOutput).arg(modelData.pulseWidth)
+            }
+        }
+    }
+
+    QGCToolInsets {
+        id:                     _toolInsets
+        leftEdgeTopInset:       parentToolInsets.leftEdgeTopInset
+        leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
+        leftEdgeBottomInset:    Math.max(parentToolInsets.leftEdgeBottomInset, servoButtonColumn.visible ? servoButtonColumn.width + (_buttonMargin * 2) : parentToolInsets.leftEdgeBottomInset)
+        rightEdgeTopInset:      parentToolInsets.rightEdgeTopInset
+        rightEdgeCenterInset:   parentToolInsets.rightEdgeCenterInset
+        rightEdgeBottomInset:   parentToolInsets.rightEdgeBottomInset
+        topEdgeLeftInset:       parentToolInsets.topEdgeLeftInset
+        topEdgeCenterInset:     parentToolInsets.topEdgeCenterInset
+        topEdgeRightInset:      parentToolInsets.topEdgeRightInset
+        bottomEdgeLeftInset:    Math.max(parentToolInsets.bottomEdgeLeftInset, servoButtonColumn.visible ? servoButtonColumn.height + (servoButtonColumn.anchors.bottomMargin * 2) : parentToolInsets.bottomEdgeLeftInset)
+        bottomEdgeCenterInset:  parentToolInsets.bottomEdgeCenterInset
+        bottomEdgeRightInset:   parentToolInsets.bottomEdgeRightInset
+    }
+}

--- a/custom/res/ServoControl/ServoControlSettingsPage.qml
+++ b/custom/res/ServoControl/ServoControlSettingsPage.qml
@@ -1,0 +1,236 @@
+/****************************************************************************
+ *
+ * (c) 2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.ScreenTools
+
+SettingsPage {
+    id: root
+
+    readonly property var controller: QGroundControl.corePlugin.servoControlController
+
+    property int editingIndex: -1
+
+    function _clearValidation() {
+        nameField.clearValidationError()
+        servoField.clearValidationError()
+        pulseField.clearValidationError()
+    }
+
+    function _resetForm() {
+        _clearValidation()
+        editingIndex = -1
+        nameField.text = ""
+        servoField.text = ""
+        pulseField.text = ""
+        nameField.focus = false
+        servoField.focus = false
+        pulseField.focus = false
+    }
+
+    function _validateForm() {
+        _clearValidation()
+
+        const trimmedName = nameField.text.trim()
+        if (!trimmedName.length) {
+            nameField.showValidationError(qsTr("Enter a button name."))
+            nameField.focus = true
+            return null
+        }
+
+        const servoValue = parseInt(servoField.text)
+        if (isNaN(servoValue)) {
+            servoField.showValidationError(qsTr("Enter a servo output number."))
+            servoField.focus = true
+            return null
+        }
+        if (servoValue < 1 || servoValue > 32) {
+            servoField.showValidationError(qsTr("Servo output must be between 1 and 32."))
+            servoField.focus = true
+            return null
+        }
+
+        const pulseValue = parseInt(pulseField.text)
+        if (isNaN(pulseValue)) {
+            pulseField.showValidationError(qsTr("Enter a PWM pulse width in microseconds."))
+            pulseField.focus = true
+            return null
+        }
+        if (pulseValue < 500 || pulseValue > 2500) {
+            pulseField.showValidationError(qsTr("PWM pulse width must be between 500 and 2500 µs."))
+            pulseField.focus = true
+            return null
+        }
+
+        return {
+            name: trimmedName,
+            servoOutput: servoValue,
+            pulseWidth: pulseValue
+        }
+    }
+
+    SettingsGroupLayout {
+        Layout.fillWidth: true
+        heading: qsTr("Servo Control Buttons")
+        headingDescription: qsTr("Configure quick access buttons that command servos from the flight controller.")
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: ScreenTools.defaultFontPixelHeight
+
+            QGCLabel {
+                Layout.fillWidth: true
+                text: editingIndex === -1 ? qsTr("Create a new button") : qsTr("Edit button %1").arg(editingIndex + 1)
+                font.bold: true
+            }
+
+            QGCLabel {
+                Layout.fillWidth: true
+                text: qsTr("Button name")
+            }
+
+            QGCTextField {
+                id: nameField
+                Layout.fillWidth: true
+                placeholderText: qsTr("Example: Drop payload")
+            }
+
+            QGCLabel {
+                Layout.fillWidth: true
+                text: qsTr("Servo output")
+            }
+
+            QGCTextField {
+                id: servoField
+                Layout.fillWidth: true
+                inputMethodHints: Qt.ImhDigitsOnly
+                placeholderText: qsTr("Servo channel (1-32)")
+            }
+
+            QGCLabel {
+                Layout.fillWidth: true
+                text: qsTr("PWM pulse width (µs)")
+            }
+
+            QGCTextField {
+                id: pulseField
+                Layout.fillWidth: true
+                inputMethodHints: Qt.ImhDigitsOnly
+                placeholderText: qsTr("Typical range 1000-2000")
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                QGCButton {
+                    Layout.preferredWidth: implicitWidth
+                    text: editingIndex === -1 ? qsTr("Add Button") : qsTr("Save Changes")
+                    enabled: controller !== null
+
+                    onClicked: {
+                        if (!controller) {
+                            return
+                        }
+                        const result = _validateForm()
+                        if (!result) {
+                            return
+                        }
+                        if (editingIndex === -1) {
+                            controller.addButton(result.name, result.servoOutput, result.pulseWidth)
+                        } else {
+                            controller.updateButton(editingIndex, result.name, result.servoOutput, result.pulseWidth)
+                        }
+                        _resetForm()
+                    }
+                }
+
+                QGCButton {
+                    visible: editingIndex !== -1
+                    text: qsTr("Cancel")
+                    onClicked: _resetForm()
+                }
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: controller && controller.buttons.length > 0
+
+            QGCLabel {
+                Layout.fillWidth: true
+                text: qsTr("Configured buttons")
+                font.bold: true
+            }
+
+            Repeater {
+                model: controller ? controller.buttons : []
+
+                delegate: Rectangle {
+                    Layout.fillWidth: true
+                    color: "transparent"
+                    border.width: 1
+                    border.color: QGroundControl.globalPalette.groupBorder
+                    radius: ScreenTools.defaultFontPixelHeight / 3
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: ScreenTools.defaultFontPixelHeight / 2
+                        spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                        QGCLabel {
+                            Layout.fillWidth: true
+                            text: modelData.name
+                            font.bold: true
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth: true
+                            text: qsTr("Servo %1 • %2 µs").arg(modelData.servoOutput).arg(modelData.pulseWidth)
+                            font.pointSize: ScreenTools.smallFontPointSize
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: ScreenTools.defaultFontPixelWidth
+
+                            QGCButton {
+                                text: qsTr("Edit")
+                                onClicked: {
+                                    editingIndex = index
+                                    nameField.text = modelData.name
+                                    servoField.text = modelData.servoOutput
+                                    pulseField.text = modelData.pulseWidth
+                                    _clearValidation()
+                                }
+                            }
+
+                            QGCButton {
+                                text: qsTr("Delete")
+                                onClicked: {
+                                    if (controller) {
+                                        controller.removeButton(index)
+                                    }
+                                    if (editingIndex === index) {
+                                        _resetForm()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom/src/HerelinkCorePlugin.cc
+++ b/custom/src/HerelinkCorePlugin.cc
@@ -9,6 +9,7 @@
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"
 #include "FactValueGrid.h"
+#include "ServoControlController.h"
 
 #include <list>
 
@@ -23,6 +24,7 @@ HerelinkCorePlugin::HerelinkCorePlugin(QObject* parent)
     : QGCCorePlugin(parent)
 {
     _herelinkOptions = new HerelinkOptions(this, nullptr);
+    _servoControlController = new ServoControlController(this);
 
     // TODO: We may need to connect to signals here instead of setToolbox
     // auto multiVehicleManager = qgcApp()->toolbox()->multiVehicleManager();

--- a/custom/src/HerelinkCorePlugin.h
+++ b/custom/src/HerelinkCorePlugin.h
@@ -11,6 +11,8 @@
 
 Q_DECLARE_LOGGING_CATEGORY(HerelinkCorePluginLog)
 
+class ServoControlController;
+
 class HerelinkCorePlugin : public QGCCorePlugin
 {
     Q_OBJECT
@@ -21,6 +23,7 @@ public:
     static HerelinkCorePlugin* instance();
 
     Q_PROPERTY(bool isHerelink READ isHerelink CONSTANT)
+    Q_PROPERTY(QObject* servoControlController READ servoControlController CONSTANT)
     bool isHerelink (void) const { return true; }
 
     // Overrides from QGCCorePlugin
@@ -30,11 +33,14 @@ public:
     void        factValueGridCreateDefaultSettings     (FactValueGrid* factValueGrid) override;
 
 
+    QObject* servoControlController() const { return _servoControlController; }
+
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);
 
 private:
     HerelinkOptions* _herelinkOptions = nullptr;
+    ServoControlController* _servoControlController = nullptr;
 };
 
 Q_APPLICATION_STATIC(HerelinkCorePlugin, _herelinkCorePluginInstance);

--- a/custom/src/ServoControl.SettingsGroup.json
+++ b/custom/src/ServoControl.SettingsGroup.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "fileType": "FactMetaData",
+    "QGC.MetaData.Facts": [
+        {
+            "name": "buttonsJson",
+            "shortDesc": "Stored servo control button configuration",
+            "type": "string",
+            "default": "[]"
+        }
+    ]
+}

--- a/custom/src/ServoControlController.cc
+++ b/custom/src/ServoControlController.cc
@@ -1,0 +1,120 @@
+#include "ServoControlController.h"
+
+#include "QGCApplication.h"
+#include "QGCToolbox.h"
+#include "MultiVehicleManager.h"
+#include "ServoControlSettings.h"
+#include "Vehicle.h"
+
+#include <QtCore/QVariantMap>
+
+#include "QGCMAVLink.h"
+
+ServoControlController::ServoControlController(QObject* parent)
+    : QObject(parent)
+    , _settings(new ServoControlSettings(this))
+{
+    connect(_settings, &ServoControlSettings::buttonsChanged, this, &ServoControlController::_onButtonsChanged);
+    _onButtonsChanged();
+}
+
+QVariantList ServoControlController::buttons() const
+{
+    return _settings ? _settings->buttons() : QVariantList{};
+}
+
+void ServoControlController::addButton(const QString& name, int servoOutput, int pulseWidth)
+{
+    if (!_settings) {
+        return;
+    }
+
+    QVariantList current = _settings->buttons();
+    QVariantMap map;
+    map.insert(QStringLiteral("name"), name);
+    map.insert(QStringLiteral("servoOutput"), servoOutput);
+    map.insert(QStringLiteral("pulseWidth"), pulseWidth);
+    current.append(map);
+    _settings->setButtons(current);
+}
+
+void ServoControlController::updateButton(int index, const QString& name, int servoOutput, int pulseWidth)
+{
+    if (!_settings) {
+        return;
+    }
+
+    QVariantList current = _settings->buttons();
+    if (index < 0 || index >= current.size()) {
+        return;
+    }
+
+    QVariantMap map = current.at(index).toMap();
+    map.insert(QStringLiteral("name"), name);
+    map.insert(QStringLiteral("servoOutput"), servoOutput);
+    map.insert(QStringLiteral("pulseWidth"), pulseWidth);
+    current[index] = map;
+    _settings->setButtons(current);
+}
+
+void ServoControlController::removeButton(int index)
+{
+    if (!_settings) {
+        return;
+    }
+
+    QVariantList current = _settings->buttons();
+    if (index < 0 || index >= current.size()) {
+        return;
+    }
+
+    current.removeAt(index);
+    _settings->setButtons(current);
+
+    if (_activeButtonIndex == index) {
+        _activeButtonIndex = -1;
+        emit activeButtonIndexChanged(_activeButtonIndex);
+    } else if (_activeButtonIndex > index) {
+        _activeButtonIndex--;
+        emit activeButtonIndexChanged(_activeButtonIndex);
+    }
+}
+
+void ServoControlController::triggerButton(int index)
+{
+    if (!_settings) {
+        return;
+    }
+
+    const QVariantList current = _settings->buttons();
+    if (index < 0 || index >= current.size()) {
+        return;
+    }
+
+    Vehicle* vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
+    if (!vehicle) {
+        qgcApp()->showAppMessage(tr("No active vehicle to send servo command."));
+        return;
+    }
+
+    const QVariantMap map = current.at(index).toMap();
+    const float servoOutput = static_cast<float>(map.value(QStringLiteral("servoOutput")).toInt());
+    const float pulseWidth = static_cast<float>(map.value(QStringLiteral("pulseWidth")).toDouble());
+
+    vehicle->sendMavCommand(vehicle->defaultComponentId(), MAV_CMD_DO_SET_SERVO, true, servoOutput, pulseWidth);
+
+    if (_activeButtonIndex != index) {
+        _activeButtonIndex = index;
+        emit activeButtonIndexChanged(_activeButtonIndex);
+    }
+}
+
+void ServoControlController::_onButtonsChanged()
+{
+    emit buttonsChanged();
+    const int buttonCount = _settings ? _settings->buttons().count() : 0;
+    if (_activeButtonIndex >= buttonCount) {
+        _activeButtonIndex = -1;
+        emit activeButtonIndexChanged(_activeButtonIndex);
+    }
+}

--- a/custom/src/ServoControlController.h
+++ b/custom/src/ServoControlController.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QVariantList>
+
+class ServoControlSettings;
+
+class ServoControlController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ServoControlController(QObject* parent = nullptr);
+
+    Q_PROPERTY(QVariantList buttons READ buttons NOTIFY buttonsChanged)
+    Q_PROPERTY(int activeButtonIndex READ activeButtonIndex NOTIFY activeButtonIndexChanged)
+
+    QVariantList buttons() const;
+    int activeButtonIndex() const { return _activeButtonIndex; }
+
+    Q_INVOKABLE void addButton(const QString& name, int servoOutput, int pulseWidth);
+    Q_INVOKABLE void updateButton(int index, const QString& name, int servoOutput, int pulseWidth);
+    Q_INVOKABLE void removeButton(int index);
+    Q_INVOKABLE void triggerButton(int index);
+
+signals:
+    void buttonsChanged();
+    void activeButtonIndexChanged(int index);
+
+private slots:
+    void _onButtonsChanged();
+
+private:
+    ServoControlSettings* _settings = nullptr;
+    int _activeButtonIndex = -1;
+};

--- a/custom/src/ServoControlSettings.cc
+++ b/custom/src/ServoControlSettings.cc
@@ -1,0 +1,105 @@
+#include "ServoControlSettings.h"
+
+#include "SettingsFact.h"
+
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonParseError>
+#include <QtCore/QString>
+#include <QtQml/qqml.h>
+
+DECLARE_SETTINGGROUP(ServoControl, "ServoControl")
+{
+    static bool registered = false;
+    if (!registered) {
+        qmlRegisterUncreatableType<ServoControlSettings>("Herelink.ServoControl", 1, 0, "ServoControlSettings", QStringLiteral("Reference only"));
+        registered = true;
+    }
+
+    _buttonsJsonFact = _createSettingsFact(buttonsJsonName);
+    connect(_buttonsJsonFact, &Fact::rawValueChanged, this, &ServoControlSettings::_updateButtons);
+    _updateButtons();
+}
+
+DECLARE_SETTINGSFACT(ServoControlSettings, buttonsJson)
+
+void ServoControlSettings::setButtons(const QVariantList& buttons)
+{
+    if (!_buttonsJsonFact) {
+        return;
+    }
+
+    const QVariantList sanitized = _sanitizeButtons(buttons);
+    QJsonArray array;
+    array.reserve(sanitized.size());
+    for (const QVariant& value : sanitized) {
+        const QVariantMap map = value.toMap();
+        QJsonObject object;
+        object.insert(QStringLiteral("name"), map.value(QStringLiteral("name")).toString());
+        object.insert(QStringLiteral("servoOutput"), map.value(QStringLiteral("servoOutput")).toInt());
+        object.insert(QStringLiteral("pulseWidth"), map.value(QStringLiteral("pulseWidth")).toDouble());
+        array.append(object);
+    }
+
+    const QJsonDocument document(array);
+    const QString json = QString::fromUtf8(document.toJson(QJsonDocument::Compact));
+    if (_buttonsJsonFact->rawValue().toString() != json) {
+        _buttonsJsonFact->setRawValue(json);
+    }
+}
+
+void ServoControlSettings::_updateButtons()
+{
+    QVariantList newButtons;
+    if (_buttonsJsonFact) {
+        const QString json = _buttonsJsonFact->rawValue().toString();
+        if (!json.isEmpty()) {
+            QJsonParseError error{};
+            const QJsonDocument document = QJsonDocument::fromJson(json.toUtf8(), &error);
+            if (error.error == QJsonParseError::NoError && document.isArray()) {
+                const QJsonArray array = document.array();
+                newButtons.reserve(array.size());
+                for (const QJsonValue& value : array) {
+                    if (!value.isObject()) {
+                        continue;
+                    }
+                    const QJsonObject object = value.toObject();
+                    QVariantMap map;
+                    map.insert(QStringLiteral("name"), object.value(QStringLiteral("name")).toString());
+                    map.insert(QStringLiteral("servoOutput"), object.value(QStringLiteral("servoOutput")).toInt());
+                    map.insert(QStringLiteral("pulseWidth"), object.value(QStringLiteral("pulseWidth")).toDouble());
+                    newButtons.append(map);
+                }
+            }
+        }
+    }
+
+    const QVariantList sanitized = _sanitizeButtons(newButtons);
+    if (_buttons != sanitized) {
+        _buttons = sanitized;
+        emit buttonsChanged();
+    }
+}
+
+QVariantList ServoControlSettings::_sanitizeButtons(const QVariantList& buttons) const
+{
+    QVariantList sanitized;
+    sanitized.reserve(buttons.size());
+    for (const QVariant& value : buttons) {
+        const QVariantMap map = value.toMap();
+        const QString name = map.value(QStringLiteral("name")).toString();
+        const int servoOutput = map.value(QStringLiteral("servoOutput")).toInt();
+        const double pulseWidth = map.value(QStringLiteral("pulseWidth")).toDouble();
+
+        if (name.trimmed().isEmpty()) {
+            continue;
+        }
+        QVariantMap cleaned;
+        cleaned.insert(QStringLiteral("name"), name);
+        cleaned.insert(QStringLiteral("servoOutput"), servoOutput);
+        cleaned.insert(QStringLiteral("pulseWidth"), pulseWidth);
+        sanitized.append(cleaned);
+    }
+    return sanitized;
+}

--- a/custom/src/ServoControlSettings.h
+++ b/custom/src/ServoControlSettings.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "SettingsGroup.h"
+
+#include <QtCore/QVariantList>
+
+class ServoControlSettings : public SettingsGroup
+{
+    Q_OBJECT
+
+public:
+    explicit ServoControlSettings(QObject* parent = nullptr);
+
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(buttonsJson)
+
+    Q_PROPERTY(QVariantList buttons READ buttons NOTIFY buttonsChanged)
+
+    QVariantList buttons() const { return _buttons; }
+    void setButtons(const QVariantList& buttons);
+
+signals:
+    void buttonsChanged();
+
+private slots:
+    void _updateButtons();
+
+private:
+    QVariantList _sanitizeButtons(const QVariantList& buttons) const;
+
+    QVariantList _buttons;
+};


### PR DESCRIPTION
## Summary
- let `ServoControlController` own its settings group instead of routing through `SettingsManager`
- override `SettingsPagesModel` from `custom/` so the Servo Control entry is injected without touching upstream QML
- revert base plugin and settings manager headers to their upstream form to avoid leaking Servo Control hooks into core code

## Testing
- `cmake -S . -B build -GNinja` *(fails: Qt 6 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc42ff7220832faa95236de2895e2e