### PR TITLE
Fix ServoControlController property return type conversion

### DIFF
--- a/custom/src/HerelinkCorePlugin.h
+++ b/custom/src/HerelinkCorePlugin.h
@@ -9,9 +9,9 @@
 #include <QObject>
 #include <QtCore/qapplicationstatic.h>
 
-Q_DECLARE_LOGGING_CATEGORY(HerelinkCorePluginLog)
+#include "ServoControlController.h"
 
-class ServoControlController;
+Q_DECLARE_LOGGING_CATEGORY(HerelinkCorePluginLog)
 
 class HerelinkCorePlugin : public QGCCorePlugin
 {


### PR DESCRIPTION
## Summary
- include ServoControlController definition in HerelinkCorePlugin to allow QObject return type conversion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccd8267750832f834dd75271f860f0