### PR TITLE
Fix servo control build issues

### DIFF
--- a/custom/src/ServoControlController.cc
+++ b/custom/src/ServoControlController.cc
@@ -1,7 +1,6 @@
 #include "ServoControlController.h"
 
 #include "QGCApplication.h"
-#include "QGCToolbox.h"
 #include "MultiVehicleManager.h"
 #include "ServoControlSettings.h"
 #include "Vehicle.h"
@@ -91,7 +90,7 @@ void ServoControlController::triggerButton(int index)
         return;
     }
 
-    Vehicle* vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
+    Vehicle* vehicle = MultiVehicleManager::instance()->activeVehicle();
     if (!vehicle) {
         qgcApp()->showAppMessage(tr("No active vehicle to send servo command."));
         return;

--- a/custom/src/ServoControlSettings.cc
+++ b/custom/src/ServoControlSettings.cc
@@ -32,7 +32,6 @@ void ServoControlSettings::setButtons(const QVariantList& buttons)
 
     const QVariantList sanitized = _sanitizeButtons(buttons);
     QJsonArray array;
-    array.reserve(sanitized.size());
     for (const QVariant& value : sanitized) {
         const QVariantMap map = value.toMap();
         QJsonObject object;


### PR DESCRIPTION
## Summary
- remove the obsolete QGCToolbox include and use the MultiVehicleManager singleton to locate the active vehicle
- stop calling QJsonArray::reserve so the servo control settings build with the Qt version used in this tree

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cce93837e4832f816a4fa68c4ce81e