### PR TITLE
Lazy instantiate Herelink servo controller

### DIFF
--- a/custom/src/HerelinkCorePlugin.cc
+++ b/custom/src/HerelinkCorePlugin.cc
@@ -24,11 +24,18 @@ HerelinkCorePlugin::HerelinkCorePlugin(QObject* parent)
     : QGCCorePlugin(parent)
 {
     _herelinkOptions = new HerelinkOptions(this, nullptr);
-    _servoControlController = new ServoControlController(this);
 
     // TODO: We may need to connect to signals here instead of setToolbox
     // auto multiVehicleManager = qgcApp()->toolbox()->multiVehicleManager();
     // connect(multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &HerelinkCorePlugin::_activeVehicleChanged);
+}
+
+QObject* HerelinkCorePlugin::servoControlController()
+{
+    if (!_servoControlController) {
+        _servoControlController = new ServoControlController(this);
+    }
+    return _servoControlController;
 }
 
 

--- a/custom/src/HerelinkCorePlugin.h
+++ b/custom/src/HerelinkCorePlugin.h
@@ -33,7 +33,7 @@ public:
     void        factValueGridCreateDefaultSettings     (FactValueGrid* factValueGrid) override;
 
 
-    QObject* servoControlController() const { return _servoControlController; }
+    QObject* servoControlController();
 
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);


### PR DESCRIPTION
## Summary
- create the Herelink servo control controller on first use so it is constructed after the core plugin

## Testing
- cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo *(fails: Qt6 SDK is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf9d1a63c832fa9d04daa29826224