### PR TITLE
Fix servo control settings display and reposition pip view

### DIFF
--- a/custom/res/ServoControl/FlyViewCustomLayer.qml
+++ b/custom/res/ServoControl/FlyViewCustomLayer.qml
@@ -27,6 +27,7 @@ Item {
     property var mapControl
 
     readonly property var controller: QGroundControl.corePlugin.servoControlController
+    readonly property bool _hasButtons: controller && controller.buttons && controller.buttons.length > 0
 
     readonly property real _buttonMargin: ScreenTools.defaultFontPixelWidth
 
@@ -37,10 +38,10 @@ Item {
         anchors.leftMargin: _buttonMargin
         anchors.bottomMargin: ScreenTools.defaultFontPixelHeight
         spacing: ScreenTools.defaultFontPixelHeight / 2
-        visible: controller && controller.buttons.length > 0
+        visible: _root.visible && _hasButtons
 
         Repeater {
-            model: controller ? controller.buttons : []
+            model: _hasButtons ? controller.buttons : []
 
             delegate: QGCButton {
                 text: modelData.name

--- a/custom/res/ServoControl/ServoControlSettingsPage.qml
+++ b/custom/res/ServoControl/ServoControlSettingsPage.qml
@@ -166,7 +166,7 @@ SettingsPage {
 
         ColumnLayout {
             Layout.fillWidth: true
-            visible: controller && controller.buttons.length > 0
+            visible: controller && controller.buttons && controller.buttons.length > 0
 
             QGCLabel {
                 Layout.fillWidth: true
@@ -175,7 +175,7 @@ SettingsPage {
             }
 
             Repeater {
-                model: controller ? controller.buttons : []
+                model: controller && controller.buttons ? controller.buttons : []
 
                 delegate: Rectangle {
                     Layout.fillWidth: true

--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -111,7 +111,8 @@ Item {
             id:                     _pipView
             anchors.left:           parent.left
             anchors.bottom:         parent.bottom
-            anchors.margins:        _toolsMargin
+            anchors.leftMargin:     _toolsMargin
+            anchors.bottomMargin:   Math.max(_toolsMargin, customOverlay.totalToolInsets.bottomEdgeLeftInset)
             item1IsFullSettingsKey: "MainFlyWindowIsMap"
             item1:                  mapControl
             item2:                  QGroundControl.videoManager.hasVideo ? videoControl : null
@@ -119,8 +120,8 @@ Item {
                                         (videoControl.pipState.state === videoControl.pipState.pipState || mapControl.pipState.state === mapControl.pipState.pipState)
             z:                      QGroundControl.zOrderWidgets
 
-            property real leftEdgeBottomInset: visible ? width + anchors.margins : 0
-            property real bottomEdgeLeftInset: visible ? height + anchors.margins : 0
+            property real leftEdgeBottomInset: visible ? width + anchors.leftMargin : 0
+            property real bottomEdgeLeftInset: visible ? height + anchors.bottomMargin : 0
         }
 
         FlyViewWidgetLayer {


### PR DESCRIPTION
## Summary
- guard against unavailable servo data in the custom settings page so it renders correctly
- hide the servo overlay when the fly view is hidden and reuse a cached button list flag
- lift the fly view picture-in-picture window above the servo buttons using the overlay insets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd047678c0832f82029ac02a2d49de