### PR TITLE
Fix servo settings page loading and pip inset loop

### DIFF
--- a/custom/res/ServoControl/FlyViewCustomLayer.qml
+++ b/custom/res/ServoControl/FlyViewCustomLayer.qml
@@ -27,8 +27,13 @@ Item {
     property var mapControl
 
     readonly property var controller: QGroundControl.corePlugin.servoControlController
+    readonly property bool _hasButtons: controller && controller.buttons && controller.buttons.length > 0
 
     readonly property real _buttonMargin: ScreenTools.defaultFontPixelWidth
+
+    readonly property real _servoBottomInset: servoButtonColumn.visible ? servoButtonColumn.height + (servoButtonColumn.anchors.bottomMargin * 2) : 0
+
+    property real servoButtonsInset: _servoBottomInset
 
     Column {
         id: servoButtonColumn
@@ -37,10 +42,10 @@ Item {
         anchors.leftMargin: _buttonMargin
         anchors.bottomMargin: ScreenTools.defaultFontPixelHeight
         spacing: ScreenTools.defaultFontPixelHeight / 2
-        visible: controller && controller.buttons.length > 0
+        visible: _root.visible && _hasButtons
 
         Repeater {
-            model: controller ? controller.buttons : []
+            model: _hasButtons ? controller.buttons : []
 
             delegate: QGCButton {
                 text: modelData.name
@@ -68,7 +73,7 @@ Item {
         topEdgeLeftInset:       parentToolInsets.topEdgeLeftInset
         topEdgeCenterInset:     parentToolInsets.topEdgeCenterInset
         topEdgeRightInset:      parentToolInsets.topEdgeRightInset
-        bottomEdgeLeftInset:    Math.max(parentToolInsets.bottomEdgeLeftInset, servoButtonColumn.visible ? servoButtonColumn.height + (servoButtonColumn.anchors.bottomMargin * 2) : parentToolInsets.bottomEdgeLeftInset)
+        bottomEdgeLeftInset:    Math.max(parentToolInsets.bottomEdgeLeftInset, _servoBottomInset)
         bottomEdgeCenterInset:  parentToolInsets.bottomEdgeCenterInset
         bottomEdgeRightInset:   parentToolInsets.bottomEdgeRightInset
     }

--- a/custom/res/ServoControl/ServoControlSettingsPage.qml
+++ b/custom/res/ServoControl/ServoControlSettingsPage.qml
@@ -14,6 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.ScreenTools
+import "qrc:/qml/QGroundControl/AppSettings"
 
 SettingsPage {
     id: root
@@ -137,7 +138,7 @@ SettingsPage {
                 QGCButton {
                     Layout.preferredWidth: implicitWidth
                     text: editingIndex === -1 ? qsTr("Add Button") : qsTr("Save Changes")
-                    enabled: controller !== null
+                    enabled: !!controller
 
                     onClicked: {
                         if (!controller) {
@@ -166,7 +167,7 @@ SettingsPage {
 
         ColumnLayout {
             Layout.fillWidth: true
-            visible: controller && controller.buttons.length > 0
+            visible: controller && controller.buttons && controller.buttons.length > 0
 
             QGCLabel {
                 Layout.fillWidth: true
@@ -175,7 +176,7 @@ SettingsPage {
             }
 
             Repeater {
-                model: controller ? controller.buttons : []
+                model: controller && controller.buttons ? controller.buttons : []
 
                 delegate: Rectangle {
                     Layout.fillWidth: true

--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -111,7 +111,8 @@ Item {
             id:                     _pipView
             anchors.left:           parent.left
             anchors.bottom:         parent.bottom
-            anchors.margins:        _toolsMargin
+            anchors.leftMargin:     _toolsMargin
+            anchors.bottomMargin:   Math.max(_toolsMargin, customOverlay.servoButtonsInset)
             item1IsFullSettingsKey: "MainFlyWindowIsMap"
             item1:                  mapControl
             item2:                  QGroundControl.videoManager.hasVideo ? videoControl : null
@@ -119,8 +120,8 @@ Item {
                                         (videoControl.pipState.state === videoControl.pipState.pipState || mapControl.pipState.state === mapControl.pipState.pipState)
             z:                      QGroundControl.zOrderWidgets
 
-            property real leftEdgeBottomInset: visible ? width + anchors.margins : 0
-            property real bottomEdgeLeftInset: visible ? height + anchors.margins : 0
+            property real leftEdgeBottomInset: visible ? width + anchors.leftMargin : 0
+            property real bottomEdgeLeftInset: visible ? height + anchors.bottomMargin : 0
         }
 
         FlyViewWidgetLayer {


### PR DESCRIPTION
## Summary
- import the core app settings module so the Servo Control settings page can instantiate SettingsPage
- disable the add button until the servo controller is ready to avoid invalid submissions
- expose the servo button inset separately and use it for the fly view pip margin to prevent the binding loop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd047678c0832f82029ac02a2d49de