### PR TITLE
Add QML import paths for Android deployment

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -31,7 +31,14 @@ TARGET   = QGroundControl
 TEMPLATE = app
 QGCROOT  = $$PWD
 
+# QML import paths used by androiddeployqt/qmlimportscanner when packaging
+# the Android build. Point to the root of our QML modules and custom resources
+# so deployment picks up QGroundControl.* modules, Custom.Widgets and the
+# gstreamer video item plugin without warnings.
 QML_IMPORT_PATH += $$PWD/src/QmlControls
+QML_IMPORT_PATH += $$PWD/src
+QML_IMPORT_PATH += $$PWD/custom/res
+QML_IMPORT_PATH += $$PWD/libs/qmlglsink
 
 #
 # OS Specific settings


### PR DESCRIPTION
## Summary
- add additional QML import paths so androiddeployqt can locate QGroundControl modules, custom widgets, and the qmlglsink plugin
- aim to reduce missing import warnings during Android packaging and improve video component deployment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3f1a18b8832fb0b023e264dc1368)