### PR TITLE
Reenable PiP in Fly View

### DIFF
--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -172,7 +172,6 @@ Item {
         item2:                  QGroundControl.videoManager.hasVideo ? videoControl : null
         fullZOrder:             _fullItemZorder
         pipZOrder:              _pipItemZorder
-        // Map PiP is disabled for the main Fly View window
-        show:                   false
+        show:                   true
     }
 }


### PR DESCRIPTION
## Summary
- reenable the PiP overlay in the main Fly view so map and video can swap

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1e5bd21c832fb66d3632c0c91d43)