### PR TITLE
Move fly view PiP overlay to left center

### DIFF
--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -165,7 +165,7 @@ Item {
     QGCPipOverlay {
         id:                     _pipOverlay
         anchors.left:           parent.left
-        anchors.bottom:         parent.bottom
+        anchors.verticalCenter: parent.verticalCenter
         anchors.margins:        _toolsMargin + widgetLayer.servoBottomInset
         item1IsFullSettingsKey: "MainFlyWindowIsMap"
         item1:                  mapControl


### PR DESCRIPTION
## Summary
- anchor the Fly View PiP overlay to the left-center of the display
- retain existing margins while shifting off the bottom edge

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d99bcd4d8832fb7e7f67bfb0af11d)